### PR TITLE
add missing dependencies and packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Install Buildstream2 and plugins:
 
 1. Install BuildStream2:
 ```
-sudo dnf install bubblewrap fuse3 git lzip patch python3
-pip3 install buildstream buildstream-external bst-plugins-experimental
+sudo dnf install bubblewrap fuse3 git lzip patch python3 python3-pip
+pip3 install buildstream buildstream-external bst-plugins-experimental buildstream-plugins dulwich
 ```
 2. Build this repo, and export to a Flatpak repo:
 ```


### PR DESCRIPTION
Some dependencies and packages are missing when running the build process in distrobox.

I'm creating the distrobox using:
```
distrobox create --image registry.fedoraproject.org/fedora-toolbox:40 --name fedora40
```

The missing Python packages are also mentioned in https://github.com/pobthebuilder/rocm-flatpak/issues/3